### PR TITLE
Update deps to remove vulnerabilities.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 node_js:
-  - "4.7"
-  - "5.12"
-  - "6.9"
-  - "7.4"
+  - "4.9"
+  - "6.17"
+  - "8.16"
+  - "10.15"
+  - "12.1"
 notifications:
   slack:
     on_success: never

--- a/package.json
+++ b/package.json
@@ -4,27 +4,32 @@
   "main": "./lib/akamai.js",
   "author": "Kanstantsin Kamkou <kkamkou@gmail.com>",
   "description": "Akamai NetStorage HTTP API for Node.js",
-  "keywords": ["akamai", "api", "http", "netstorage"],
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/kkamkou/node-akamai-http-api.git"
+  "keywords": [
+    "akamai",
+    "api",
+    "http",
+    "netstorage"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kkamkou/node-akamai-http-api.git"
   },
-  "bugs" : {
-    "url" : "https://github.com/kkamkou/node-akamai-http-api/issues"
+  "bugs": {
+    "url": "https://github.com/kkamkou/node-akamai-http-api/issues"
   },
-  "license" : "MIT",
+  "license": "MIT",
   "scripts": {
     "test": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "dependencies": {
-    "lodash": "~4.16",
-    "request": "~2.78",
+    "lodash": "^4.17.11",
+    "request": "^2.88.0",
     "xml2js": ">=0.4.16"
   },
   "devDependencies": {
-    "coveralls": "~2.11",
+    "coveralls": "^3.0.3",
     "istanbul": "~0.4.3",
-    "mocha": "~3.1",
+    "mocha": "^6.1.4",
     "should": "~11.1"
   }
 }


### PR DESCRIPTION
Installing v0.6.0 currently results in the following output form `npm`:

```
found 18 vulnerabilities (2 low, 13 moderate, 2 high, 1 critical)
  run `npm audit fix` to fix them, or `npm audit` for details
```

This changeset was created by running `npm audit fix —-force` and then updating the `.travis.yml` to include newer versions of Node runtime.